### PR TITLE
correctly detect CentOS

### DIFF
--- a/ice_setup.py
+++ b/ice_setup.py
@@ -762,6 +762,8 @@ def _normalized_distro_name(distro):
         return 'scientific'
     elif distro.startswith(('suse', 'opensuse')):
         return 'suse'
+    elif distro.startswith('centos'):
+        return 'centos'
     return distro
 
 


### PR DESCRIPTION
this affected `ceph-deploy` at some point, this will prevent us having issues when/if ICE supports CentOS 7

CentOS 7 has a new naming convention which breaks this detection (`CentOS` vs `CentOS Linux`)
