### PR TITLE
print how repo files would look like 

### DIFF
--- a/ice_setup.py
+++ b/ice_setup.py
@@ -428,8 +428,8 @@ gpgkey={gpg_url}
 ceph_yum_template = """
 [ceph]
 name=Ceph
-baseurl={ceph_url}
-gpgkey={ceph_gpg_url}
+baseurl={repo_url}
+gpgkey={gpg_url}
 default=true
 proxy=_none_
 """
@@ -1277,8 +1277,8 @@ def default():
     distro = get_distro()
     distro.pkg_manager.print_repo_file(
         'ceph',
-        ceph_url,
-        ceph_gpg_url,
+        repo_url=ceph_url,
+        gpg_url=ceph_gpg_url,
         codename=distro.codename,
     )
 


### PR DESCRIPTION
So that users that do not wish to use `ceph-deploy` can use this as part of their deployment procedure.

For YUM (CentOS box output) it would look like:
![screen shot 2014-07-22 at 9 08 01 am](https://cloud.githubusercontent.com/assets/317847/3658281/8d354bf4-11a1-11e4-8343-6d1902290f15.png)

And for Debian:

![screen shot 2014-07-22 at 9 07 36 am](https://cloud.githubusercontent.com/assets/317847/3658284/9781aba2-11a1-11e4-9325-feadebe5879d.png)
