### PR TITLE
Wip 9583

### DIFF
--- a/ice_setup.py
+++ b/ice_setup.py
@@ -28,7 +28,6 @@
 import logging
 import os
 import platform
-import re
 import shutil
 import socket
 import subprocess


### PR DESCRIPTION
Fix unreported bug in run_get_stdout, remove unused import re, and fix #9583.
