### PR TITLE
DNM - debian sync/updates

### DIFF
--- a/ice_setup.py
+++ b/ice_setup.py
@@ -460,6 +460,16 @@ priority=1
 proxy=_none_
 """
 
+ceph_online_yum_template = """
+[ceph_online]
+name=Ceph_online packages
+baseurl={repo_url}
+gpgkey={gpg_url}
+default=true
+priority=1
+proxy=_none_
+"""
+
 ceph_apt_template = """deb {repo_url} {codename} main\n"""
 
 calamari_apt_template = """deb {repo_url} {codename} main\n"""

--- a/ice_setup.py
+++ b/ice_setup.py
@@ -1656,10 +1656,11 @@ class UpdateRepo(object):
 
 def update_repo(repos):
     distro = get_distro()
-    if len(repos) > 1:
-        logger.debug('updating repo: %s' % repos)
-    else:
-        logger.debug('updating repos: %s' % ' '.join(repos))
+    logger.debug('updating repo%s: %s' % (
+        's' if len(repos) > 1 else '',
+        ' '.join(repos)
+        )
+    )
     distro.pkg_manager.sync(repos)
 
 # =============================================================================

--- a/ice_setup.py
+++ b/ice_setup.py
@@ -1352,7 +1352,7 @@ def configure_ceph_deploy(master, minion_url, minion_gpg_url,
             rc_file.write(contents)
 
 
-def configure_local(name, repo_path=None):
+def configure_local(name, repo_path=None, repo_only=False):
     """
     Configure the current host so that it can serve as a *local* repo server
     and we can then install Calamari and ceph-deploy.
@@ -1375,13 +1375,14 @@ def configure_local(name, repo_path=None):
     )
 
     # overwrite the repo with the new packages
-    overwrite_dir(
-        repo_path,
-        destination=os.path.join(
-            repo_dest_prefix,
-            name,
+    if not repo_only:
+        overwrite_dir(
+            repo_path,
+            destination=os.path.join(
+                repo_dest_prefix,
+                name,
+            )
         )
-    )
 
     distro = get_distro()
     distro.pkg_manager.create_repo_file(
@@ -1398,7 +1399,7 @@ def configure_local(name, repo_path=None):
 
     # call update on the package manager
     distro.pkg_manager.update()
-    logger.info('this host now has a local repository for ceph-deploy, and Calamari')
+    logger.info('this host now has a local repository for %s' % name)
     logger.info('you can install those packages with your package manager')
 
 

--- a/ice_setup.py
+++ b/ice_setup.py
@@ -439,6 +439,17 @@ priority=1
 gpgkey={gpg_url}
 """
 
+calamari_online_yum_template = """
+[calamari_online]
+name=calamari_online packages for $basearch
+baseurl={repo_url}
+enabled=1
+gpgcheck=1
+type=rpm-md
+priority=1
+gpgkey={gpg_url}
+"""
+
 ceph_yum_template = """
 [ceph]
 name=Ceph

--- a/ice_setup.py
+++ b/ice_setup.py
@@ -775,9 +775,9 @@ class Apt(object):
 
         # piggy back from the local repos
         gpg_locations = {
-            'ceph': 'file://%s' % os.path.join(ceph_repo_path, 'release.asc'),
-            'ceph-deploy': 'file:///opt/ICE/ceph-deploy/release.asc',
-            'calamari-server': 'file:///opt/ICE/calamari-server/release.asc',
+            'ceph': '%s' % os.path.join(ceph_repo_path, 'release.asc'),
+            'ceph-deploy': '/opt/ICE/ceph-deploy/release.asc',
+            'calamari-server': '/opt/ICE/calamari-server/release.asc',
         }
 
         distro = get_distro()

--- a/ice_setup.py
+++ b/ice_setup.py
@@ -36,6 +36,7 @@ import tarfile
 import tempfile
 import urllib2
 import urlparse
+from ConfigParser import SafeConfigParser, NoSectionError, NoOptionError
 
 from functools import wraps
 from textwrap import dedent
@@ -601,6 +602,46 @@ class Yum(object):
         pass
 
     @classmethod
+    def sync(cls, repos):
+        # resolve needed dependencies
+        if not which('syncrepo'):
+            self.install('yum-utils')
+        if not which('createrepo'):
+            self.install('createrepo')
+
+        # infer the path to the ceph repo by looking at cephdeploy.conf because
+        # we never overwrite ceph, rather, we rely on versions so the path for
+        # ceph can have multiple versions already, like ``static/ceph/0.80``
+        # and ``static/ceph/0.86``
+        destinations = {
+            'ceph' : infer_ceph_repo(),
+            'ceph-deploy': '/opt/ICE/ceph-deploy',
+            'calamari': '/opt/ICE/calamari-server',
+        }
+
+        repo_ids = {
+            'ceph-deploy': 'ceph_deploy_online',
+            'ceph': 'ceph_online',
+            'calamari': 'calamari_online',
+
+        for repo in repos:
+            destination = destinations[repo]
+            repoid = repo_ids[repo]
+            run(
+                [
+                    'reposync',
+                    '--repoid=%s' % repoid,
+                    '--newest-only',
+                    '--norepopath',
+                    '-p',
+                    destination
+                ]
+            )
+
+
+
+
+    @classmethod
     def enumerate_repo(cls, path):
         """find rpms in path and return their package names"""
         # make list of rpm files relative to path
@@ -972,6 +1013,82 @@ def get_repo_path(repo_dir_name=None, traverse=False):
         raise FileNotFound(repo_path)
     logger.debug('detected repository path: %s', repo_path)
     return repo_path
+
+
+def get_ceph_deploy_conf_paths():
+    """
+    Return all the possible cephdeploy.conf locations including the one for
+    ``root`` if the user is calling us with ``sudo`` and not as ``root`` user.
+    """
+    configs = [
+        os.path.join(os.getcwd(), 'cephdeploy.conf'),
+        os.path.expanduser(u'~/.cephdeploy.conf'),
+    ]
+    sudoer_user = os.environ.get('SUDO_USER')
+    if sudoer_user:
+        sudoer_home = os.path.expanduser('~' + sudoer_user)
+        configs.append(os.path.join(sudoer_home, '.cephdeploy.conf'))
+
+    return configs
+
+
+# =============================================================================
+# System Utils
+# =============================================================================
+
+
+def which(executable):
+    """find the location of an executable"""
+    if 'PATH' in os.environ:
+        envpath = os.environ['PATH']
+    else:
+        envpath = os.defpath
+    PATH = envpath.split(os.pathsep)
+
+    locations = PATH + [
+        '/usr/local/bin',
+        '/bin',
+        '/usr/bin',
+        '/usr/local/sbin',
+        '/usr/sbin',
+        '/sbin',
+    ]
+
+    for location in locations:
+        executable_path = os.path.join(location, executable)
+        if os.path.exists(executable_path):
+            return executable_path
+
+
+def infer_ceph_repo():
+    configs = get_ceph_deploy_conf_paths()
+    config = None
+    for conf in configs:
+        if os.path.exists(conf):
+            config = conf
+            break
+
+    if not config:
+        logger.error('tried looking for a valid cephdeploy.conf file but failed')
+        raise FileNotFound(configs[0])
+
+    parser = SafeConfigParser()
+    parser.read(config)
+
+    try:
+        http_path = parser.get(section, key)
+    except (NoSectionError, NoOptionError):
+        msg = 'could not find a ``ceph`` repo section at %s' % config
+        raise ICEError(msg)
+
+    directories = http_path.split('/')
+    # if we had a trailing slash fallback the next item
+    # In [4]: 'http://fqdn/static/ceph/0.80/'.split('/')
+    # Out[4]: ['http:', '', 'fqdn', 'static', 'ceph', '0.80', '']
+    directory = directories[-1] or directories[-2]
+
+    return os.path.join('/opt/calamari/webapp/content/ceph', directory)
+
 
 
 # =============================================================================
@@ -1451,7 +1568,12 @@ class UpdateRepo(object):
 
 
 def update_repo(repos):
-    pass
+    distro = get_distro()
+    if len(repos) > 1:
+        logger.debug('updating repo: %s' % repos)
+    else:
+        logger.debug('updating repos: %s' % ' '.join(repos))
+    distro.pkg_manager.sync(repos)
 
 # =============================================================================
 # Main

--- a/ice_setup.py
+++ b/ice_setup.py
@@ -1397,12 +1397,69 @@ def interactive_help(mode='interactive mode'):
     prompt_continue()
 
 
+class UpdateRepo(object):
+
+    _help = dedent("""
+    Connects to updated repositories and fetch updates to packages for the
+    local repos.
+
+    Commands:
+
+      all         Updates all repositories configured for this host
+                  (ceph, ceph-deploy, and calamari)
+
+    Optional Arguments:
+
+      ceph        Update the ceph repo
+      ceph-deploy Update the ceph-deploy repo
+      calamari    Update the calamari repo
+
+    Examples:
+
+    Update all of the repos available:
+
+      sudo python ice_setup.py update all
+
+    Update the calamari and ceph repos:
+
+      sudo python ice_setup.py update ceph-deploy calamari
+
+    Update just the ceph-deploy repository:
+
+      sudo python ice_setup.py update ceph-deploy
+    """)
+
+    def __init__(self, argv):
+        self.argv = argv
+        self.optional_arguments = ['ceph', 'ceph-deploy', 'calamari']
+
+    def parse_args(self):
+        options = ['all']
+        parser = Transport(self.argv, options=options)
+        parser.catch_help = self._help
+        parser.parse_args()
+
+        #sudo_check()
+
+        if parser.has('all'):
+            update_repo(self.optional_arguments)
+        else:
+            if parser.arguments:
+                update_repo(
+                        [i for i in parser.arguments if i in self.optional_arguments]
+                )
+
+
+def update_repo(repos):
+    pass
+
 # =============================================================================
 # Main
 # =============================================================================
 
 command_map = {
     'configure': Configure,
+    'update': UpdateRepo,
 }
 
 
@@ -1413,6 +1470,7 @@ def ice_help():
     Subcommands:
 
       configure         Configuration of the ICE node
+      update            Update local repositories from hosted repos.
     """
     return '%s\n%s\n%s\n%s' % (
         help_header,

--- a/ice_setup.py
+++ b/ice_setup.py
@@ -1611,6 +1611,8 @@ class UpdateRepo(object):
       all         Updates all repositories configured for this host
                   (ceph, ceph-deploy, and calamari)
 
+      configure   Installs/updates (all) the repo files for updates
+
     Optional Arguments:
 
       ceph        Update the ceph repo
@@ -1637,7 +1639,7 @@ class UpdateRepo(object):
         self.optional_arguments = ['ceph', 'ceph-deploy', 'calamari']
 
     def parse_args(self):
-        options = ['all']
+        options = ['all', 'configure']
         parser = Transport(self.argv, options=options)
         parser.catch_help = self._help
         parser.parse_args()
@@ -1646,6 +1648,13 @@ class UpdateRepo(object):
 
         if parser.has('all'):
             update_repo(self.optional_arguments)
+
+        if parser.has('configure'):
+            # configure the updates repos:
+            configure_updates('calamari-server-updates')
+            configure_updates('ceph-deploy-updates')
+            configure_updates('ceph-updates')
+
         else:
             if parser.arguments:
                 update_repo(

--- a/ice_setup.py
+++ b/ice_setup.py
@@ -515,6 +515,10 @@ yum_templates = {
     'calamari-server': calamari_yum_template,
     'ceph-deploy': ceph_deploy_yum_template,
     'ceph': ceph_yum_template,
+    'calamari-server-online': calamari_online_yum_template,
+    'ceph-deploy-online': ceph_deploy_online_yum_template,
+    'ceph-online': ceph_online_yum_template,
+
 }
 
 apt_templates = {

--- a/ice_setup.py
+++ b/ice_setup.py
@@ -1563,8 +1563,7 @@ def default():
     # configure the updates repos:
     configure_updates('calamari-server-updates')
     configure_updates('ceph-deploy-updates')
-
-
+    configure_updates('ceph-updates')
 
     logger.info('Setup has completed.')
     logger.info('If installing Calamari for the first time:')

--- a/ice_setup.py
+++ b/ice_setup.py
@@ -417,6 +417,17 @@ priority=1
 gpgkey={gpg_url}
 """
 
+ceph_deploy_online_yum_template = """
+[ceph_deploy_online]
+name=ceph_deploy_online packages for $basearch
+baseurl={repo_url}
+enabled=1
+gpgcheck=1
+type=rpm-md
+priority=1
+gpgkey={gpg_url}
+"""
+
 calamari_yum_template = """
 [calamari]
 name=calamari packages for $basearch
@@ -1556,7 +1567,7 @@ class UpdateRepo(object):
         parser.catch_help = self._help
         parser.parse_args()
 
-        #sudo_check()
+        sudo_check()
 
         if parser.has('all'):
             update_repo(self.optional_arguments)

--- a/ice_setup.py
+++ b/ice_setup.py
@@ -1363,9 +1363,9 @@ def configure_updates(name):
                  calamari-server-updates or ceph-deploy-updates
     """
     update_repo_urls = {
+        # XXX these need the right url, stubs for now.
         'ceph-updates': 'http://ceph.com/rpm-firefly/el6/x86_64/',
         'ceph-deploy-updates': 'http://ceph.com/rpm-firefly/el6/noarch/',
-        # XXX this needs the right url
         'calamari-server-updates': 'http://ceph.com/rpm-firefly/el6/noarch/',
     }
 
@@ -1474,6 +1474,7 @@ def default():
         '2. Install Calamari web application on the ICE Node (current host)',
         '3. Install ceph-deploy on the ICE Node (current host)',
         '4. Configure host as a ceph and calamari minion repository for remote hosts',
+        '5. Calamari minion repository setup',
     ]
 
     logger.info('this script will setup Calamari, package repo, and ceph-deploy')

--- a/ice_setup.py
+++ b/ice_setup.py
@@ -1560,11 +1560,20 @@ def default():
         codename=distro.codename,
     )
 
+    # step six, the song ended, there is no six, lets try with
+    # some bricks jumping up and down like tics that cliques
+    logger.info('')
+    logger.info('\
+        {markup} \
+        Step 6: Configure the update repositories \
+        {markup}'.format(markup='===='))
+    logger.info('')
     # configure the updates repos:
     configure_updates('calamari-server-updates')
     configure_updates('ceph-deploy-updates')
     configure_updates('ceph-updates')
 
+    logger.info('')
     logger.info('Setup has completed.')
     logger.info('If installing Calamari for the first time:')
     logger.info('')

--- a/ice_setup.py
+++ b/ice_setup.py
@@ -1653,21 +1653,23 @@ def default():
 
     # step six, the song ended, there is no six, lets try with
     # some bricks jumping up and down like tics that cliques
-    logger.info('')
-    logger.info('\
-        {markup} \
-        Step 6: Configure the update repositories \
-        {markup}'.format(markup='===='))
-    logger.info('')
-    logger.info('You will need to provide your credentials for the update repositories')
+    if distro.name not in ['ubuntu', 'debian']:
+        # only those distros don't require to have repo files created
+        logger.info('')
+        logger.info('\
+            {markup} \
+            Step 6: Configure the update repositories \
+            {markup}'.format(markup='===='))
+        logger.info('')
+        logger.info('You will need to provide your credentials for the update repositories')
 
-    updates_username = prompt('Username:')
-    updates_password = prompt_pass('Password:')
+        updates_username = prompt('Username:')
+        updates_password = prompt_pass('Password:')
 
-    # configure the updates repos:
-    configure_updates('calamari-server-updates', updates_username, updates_password)
-    configure_updates('ceph-deploy-updates', updates_username, updates_password)
-    configure_updates('ceph-updates', updates_username, updates_password)
+        # configure the updates repos:
+        configure_updates('calamari-server-updates', updates_username, updates_password)
+        configure_updates('ceph-deploy-updates', updates_username, updates_password)
+        configure_updates('ceph-updates', updates_username, updates_password)
 
     logger.info('')
     logger.info('Setup has completed.')

--- a/ice_setup.py
+++ b/ice_setup.py
@@ -789,8 +789,8 @@ class Apt(object):
             # ensure the GPG key is imported
             run(
                 [
-                    'gpg ',
-                    '--no-default-keyring ',
+                    'gpg',
+                    '--no-default-keyring',
                     '--keyring',
                     'trustedkeys.gpg',
                     '--import',
@@ -866,7 +866,7 @@ def run(cmd, **kw):
             if err == '' and process.poll() is not None:
                 break
             if err != '':
-                logger.warning(err)
+                logger.warning(err.strip('\n'))
                 sys.stderr.flush()
     if process.stdout:
         while True:
@@ -898,7 +898,7 @@ def run_get_stdout(cmd, **kw):
     )
     out, err = process.communicate()
     if err:
-        logger.warning(err)
+        logger.warning(err.strip('\n'))
 
     if process.returncode != 0:
         error_msg = "command returned non-zero exit status: %s" % process.returncode

--- a/ice_setup.py
+++ b/ice_setup.py
@@ -801,9 +801,10 @@ class Apt(object):
             run(
                 [
                    'debmirror',
+                   '--verbose',
                    '-a', 'amd64',
                    '--no-source',
-                   '-s', 'main ',
+                   '-s', 'main',
                    '-h', 'ceph.com', # XXX stub
                    '-d', distro.codename,
                    '-r', 'debian-firefly',  # XXX stub

--- a/ice_setup.py
+++ b/ice_setup.py
@@ -1098,8 +1098,8 @@ def which(executable):
             return executable_path
 
 
-def infer_ceph_repo():
-    configs = get_ceph_deploy_conf_paths()
+def infer_ceph_repo(_configs=None):
+    configs = _configs or get_ceph_deploy_conf_paths()
     config = None
     for conf in configs:
         if os.path.exists(conf):
@@ -1375,7 +1375,6 @@ def configure_updates(name):
         'ceph-deploy-updates': 'file:///opt/ICE/ceph-deploy/release.asc',
         'calamari-server-updates': 'file:///opt/ICE/calamari-server/release.asc',
     }
-
 
     distro = get_distro()
     distro.pkg_manager.create_repo_file(

--- a/ice_setup.py
+++ b/ice_setup.py
@@ -1383,13 +1383,13 @@ def configure_updates(name, username=None, password=None):
     if not username or not password:
         logger.info('You will need to provide your credentials for the update repository')
         username = prompt('Username:')
-        password = prompt_pass('Password:')
+        password = prompt_pass()
 
     update_repo_urls = {
         # XXX these need the right url, stubs for now.
-        'ceph-updates': 'http://ceph.com/rpm-firefly/el6/x86_64/',
-        'ceph-deploy-updates': 'http://ceph.com/rpm-firefly/el6/noarch/',
-        'calamari-server-updates': 'http://ceph.com/rpm-firefly/el6/noarch/',
+        'ceph-updates': 'http://{user}:{password}@ceph.com/rpm-firefly/el6/x86_64/',
+        'ceph-deploy-updates': 'http://{user}:{password}@ceph.com/rpm-firefly/el6/noarch/',
+        'calamari-server-updates': 'http://{user}:{password}@ceph.com/rpm-firefly/el6/noarch/',
     }
 
     # piggy back from the local repos
@@ -1399,11 +1399,19 @@ def configure_updates(name, username=None, password=None):
         'calamari-server-updates': 'file:///opt/ICE/calamari-server/release.asc',
     }
 
+    repo_url = update_repo_urls[name].format(
+        user=username,
+        password=password,
+    )
+
+    gpg_url = update_gpg_urls[name]
+
+
     distro = get_distro()
     distro.pkg_manager.create_repo_file(
         name,
-        update_repo_urls[name],
-        update_gpg_urls[name],
+        repo_url,
+        gpg_url,
         file_name=name,
         codename=distro.codename,
     )
@@ -1688,9 +1696,14 @@ class UpdateRepo(object):
 
         if parser.has('configure'):
             # configure the updates repos:
-            configure_updates('calamari-server-updates')
-            configure_updates('ceph-deploy-updates')
-            configure_updates('ceph-updates')
+            logger.info('You will need to provide your credentials for the update repositories')
+
+            username = prompt('Username:')
+            password = prompt_pass()
+
+            configure_updates('calamari-server-updates', username, password)
+            configure_updates('ceph-deploy-updates', username, password)
+            configure_updates('ceph-updates', username, password)
 
         else:
             if parser.arguments:

--- a/ice_setup.py
+++ b/ice_setup.py
@@ -809,6 +809,7 @@ class Apt(object):
                    '-d', distro.codename,
                    '-r', 'debian-firefly',  # XXX stub
                    '--method', 'http',
+                   '--ignore', 'release.asc', # do not delete release.asc files
                    '--progress',
                    destination,
                 ]

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -17,37 +17,37 @@ def etc_path():
 class TestYum(object):
 
     def test_creates_default_file(self, etc_path):
-        Yum.create_repo_file('repo_url', 'gpg_url', etc_path=etc_path)
+        Yum.create_repo_file('ceph', 'repo_url', 'gpg_url', etc_path=etc_path)
         assert os.path.isfile(os.path.join(etc_path, 'ice.repo'))
 
     def test_gpg_url_default_file(self, etc_path):
-        Yum.create_repo_file('repo_url', 'gpg_url', etc_path=etc_path)
+        Yum.create_repo_file('ceph', 'repo_url', 'gpg_url', etc_path=etc_path)
         repo_file_path = os.path.join(etc_path, 'ice.repo')
         with open(repo_file_path) as contents:
             contents = contents.read()
         assert 'gpg_url' in contents
 
     def test_repo_url_default_file(self, etc_path):
-        Yum.create_repo_file('/opt/ICE/repo', 'gpg_url', etc_path=etc_path)
+        Yum.create_repo_file('ceph', '/opt/ICE/repo', 'gpg_url', etc_path=etc_path)
         repo_file_path = os.path.join(etc_path, 'ice.repo')
         with open(repo_file_path) as contents:
             contents = contents.read()
         assert '/opt/ICE/repo' in contents
 
     def test_creates_custom_file(self, etc_path):
-        Yum.create_repo_file('repo_url', 'gpg_url', file_name='foo', etc_path=etc_path)
-        assert os.path.isfile(os.path.join(etc_path, 'foo'))
+        Yum.create_repo_file('ceph', 'repo_url', 'gpg_url', file_name='foo', etc_path=etc_path)
+        assert os.path.isfile(os.path.join(etc_path, 'foo.repo'))
 
     def test_gpg_url_custom_file(self, etc_path):
-        Yum.create_repo_file('repo_url', 'gpg_url', file_name='foo', etc_path=etc_path)
-        repo_file_path = os.path.join(etc_path, 'foo')
+        Yum.create_repo_file('ceph', 'repo_url', 'gpg_url', file_name='foo', etc_path=etc_path)
+        repo_file_path = os.path.join(etc_path, 'foo.repo')
         with open(repo_file_path) as contents:
             contents = contents.read()
         assert 'gpg_url' in contents
 
     def test_repo_url_custom_file(self, etc_path):
-        Yum.create_repo_file('/opt/ICE/repo', 'gpg_url', file_name='foo',  etc_path=etc_path)
-        repo_file_path = os.path.join(etc_path, 'foo')
+        Yum.create_repo_file('ceph', '/opt/ICE/repo', 'gpg_url', file_name='foo',  etc_path=etc_path)
+        repo_file_path = os.path.join(etc_path, 'foo.repo')
         with open(repo_file_path) as contents:
             contents = contents.read()
         assert '/opt/ICE/repo' in contents
@@ -56,37 +56,37 @@ class TestYum(object):
 class TestApt(object):
 
     def test_creates_default_file(self, etc_path):
-        Apt.create_repo_file('repo_url', 'gpg_url', etc_path=etc_path, codename='saucy')
+        Apt.create_repo_file('ceph', 'repo_url', 'gpg_url', etc_path=etc_path, codename='saucy')
         assert os.path.isfile(os.path.join(etc_path, 'ice.list'))
 
     def test_gpg_url_default_file(self, etc_path):
-        Apt.create_repo_file('repo_url', 'gpg_url', etc_path=etc_path, codename='saucy')
+        Apt.create_repo_file('ceph', 'repo_url', 'gpg_url', etc_path=etc_path, codename='saucy')
         repo_file_path = os.path.join(etc_path, 'ice.list')
         with open(repo_file_path) as contents:
             contents = contents.read()
         assert 'repo_url' in contents
 
     def test_repo_url_default_file(self, etc_path):
-        Apt.create_repo_file('/opt/ICE/repo', 'gpg_url', etc_path=etc_path, codename='saucy')
+        Apt.create_repo_file('ceph', '/opt/ICE/repo', 'gpg_url', etc_path=etc_path, codename='saucy')
         repo_file_path = os.path.join(etc_path, 'ice.list')
         with open(repo_file_path) as contents:
             contents = contents.read()
         assert '/opt/ICE/repo' in contents
 
     def test_creates_custom_file(self, etc_path):
-        Apt.create_repo_file('repo_url', 'gpg_url', file_name='foo', etc_path=etc_path, codename='saucy')
-        assert os.path.isfile(os.path.join(etc_path, 'foo'))
+        Apt.create_repo_file('ceph', 'repo_url', 'gpg_url', file_name='foo', etc_path=etc_path, codename='saucy')
+        assert os.path.isfile(os.path.join(etc_path, 'foo.list'))
 
     def test_gpg_url_custom_file(self, etc_path):
-        Apt.create_repo_file('repo_url', 'gpg_url', file_name='foo', etc_path=etc_path, codename='saucy')
-        repo_file_path = os.path.join(etc_path, 'foo')
+        Apt.create_repo_file('ceph', 'repo_url', 'gpg_url', file_name='foo', etc_path=etc_path, codename='saucy')
+        repo_file_path = os.path.join(etc_path, 'foo.list')
         with open(repo_file_path) as contents:
             contents = contents.read()
         assert 'repo_url' in contents
 
     def test_repo_url_custom_file(self, etc_path):
-        Apt.create_repo_file('/opt/ICE/repo', 'gpg_url', file_name='foo',  etc_path=etc_path, codename='saucy')
-        repo_file_path = os.path.join(etc_path, 'foo')
+        Apt.create_repo_file('ceph', '/opt/ICE/repo', 'gpg_url', file_name='foo',  etc_path=etc_path, codename='saucy')
+        repo_file_path = os.path.join(etc_path, 'foo.list')
         with open(repo_file_path) as contents:
             contents = contents.read()
         assert '/opt/ICE/repo' in contents

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1,8 +1,23 @@
-from ice_setup import get_fqdn
+import os
+import tempfile
+from pytest import raises
+import pytest
+from textwrap import dedent
+from ice_setup import get_fqdn, infer_ceph_repo, ICEError, FileNotFound
 
 
 class FakeSocket(object):
     pass
+
+
+@pytest.fixture
+def cephdeploy_conf():
+    path = tempfile.mkstemp()
+
+    def fin():
+        os.remove(path)
+
+    return path[-1]
 
 
 class TestGetFQDN(object):
@@ -21,3 +36,36 @@ class TestGetFQDN(object):
     def test_valid_fqdn(self):
         self.sock.getfqdn = lambda: 'zombo.com'
         assert get_fqdn(_socket=self.sock) == 'zombo.com'
+
+
+class TestInferCephRepo(object):
+
+    def test_does_not_find_cephdeployconf(self):
+        with raises(FileNotFound):
+            infer_ceph_repo(_configs=[''])
+
+    def test_does_not_find_a_ceph_repo_section(self, cephdeploy_conf):
+        with raises(ICEError):
+            infer_ceph_repo(_configs=[cephdeploy_conf])
+
+    def test_does_find_a_ceph_repo_section(self, cephdeploy_conf):
+        print cephdeploy_conf
+
+        with open(cephdeploy_conf, 'w') as f:
+            f.write(dedent("""
+            [ceph]
+            baseurl=http://fqdn/static/ceph/0.80
+            """))
+        result = infer_ceph_repo(_configs=[cephdeploy_conf])
+        assert result == '/opt/calamari/webapp/content/ceph/0.80'
+
+    def test_deals_with_non_trailing_slashes(self, cephdeploy_conf):
+        print cephdeploy_conf
+
+        with open(cephdeploy_conf, 'w') as f:
+            f.write(dedent("""
+            [ceph]
+            baseurl=http://fqdn/static/ceph/0.80/
+            """))
+        result = infer_ceph_repo(_configs=[cephdeploy_conf])
+        assert result == '/opt/calamari/webapp/content/ceph/0.80'


### PR DESCRIPTION
Reference ticket: http://tracker.ceph.com/issues/9687
By using `debmirror` it implements repository updates for DEB packages. As opposed to the YUM updates, there is no need for us to create repo files as `debmirror` only needs paths and CLI values.

Since this is a branch off of wip-9686 all those commits show here as well.

The work to implement this sync with `debmirror` was fueled by this guide: https://help.ubuntu.com/community/Debmirror
**note**: this will now add a new requirement: `debmirror`
