### PR TITLE
packaging: rename package to avoid space character

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='ICE setup',
+    name='ice_setup',
     author='Inktank',
     version='0.0.1',
     packages=find_packages(),


### PR DESCRIPTION
This pull request adjusts the package name in `setup.py` to avoid having a space in the tarball name.

This also uses lower-case "ice" to match the `ice_setup.py` filename.
