### PR TITLE
packaging: use version number from ice_setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 from setuptools import setup, find_packages
+from ice_setup import __version__
 
 setup(
     name='ice_setup',
     author='Inktank',
-    version='0.0.1',
+    version=__version__,
     packages=find_packages(),
     zip_safe=False,
 )


### PR DESCRIPTION
Avoid hardcoding the ice_setup version number in two places. Make `setup.py` query `ice_setup.py` for its version number.

Relates to https://bugzilla.redhat.com/1181781, "tag a new version for ice-setup"
