### PR TITLE
packaging: run pytest in "setup.py test"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,25 @@
+import sys
 from setuptools import setup, find_packages
+from setuptools.command.test import test as TestCommand
 from ice_setup.ice import __version__
+
+class PyTest(TestCommand):
+    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.pytest_args = []
+
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
+
+    def run_tests(self):
+        #import here, cause outside the eggs aren't loaded
+        import pytest
+        errno = pytest.main(self.pytest_args)
+        sys.exit(errno)
 
 setup(
     name='ice_setup',
@@ -13,4 +33,6 @@ setup(
             'ice_setup = ice_setup.ice:main',
         ],
     },
+    tests_require=['pytest'],
+    cmdclass = {'test': PyTest},
 )


### PR DESCRIPTION
This PR adds a helper to setup.py that invokes pytest.

We can now run `python setup.py test` to run all the tests during the RPM build.

Based on code from http://pytest.org/latest/goodpractises.html
