### PR TITLE
Implement homegrown strtobool

### DIFF
--- a/ice_setup.py
+++ b/ice_setup.py
@@ -987,8 +987,8 @@ def prompt_bool(question, _raw_input=None):
     try:
         return strtobool(response)
     except ValueError:
-        logger.error('Valid true responses are: y, Y, 1, Enter')
-        logger.error('Valid false responses are: n, N, 0')
+        logger.error('Valid true responses are: y, yes, <Enter>')
+        logger.error('Valid false responses are: n, no')
         logger.error('That response was invalid, please try again')
         return prompt_bool(question, _raw_input=input_prompt)
 
@@ -1026,24 +1026,25 @@ def prompt(question, default=None, lowercase=False, _raw_input=None):
 
 def strtobool(val):
     """
-    Convert a string representation of truth to true (1) or false (0).
+    Convert a string representation of truth to True or False
 
-    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values are
-    'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if 'val' is
-    anything else.
-
-    .. note:: lifted from distutils.utils.strtobool
+    True values are 'y', 'yes', or ''; case-insensitive
+    False values are 'n', or 'no'; case-insensitive
+    Raises ValueError if 'val' is anything else.
     """
+    true_vals = ['yes', 'y', '']
+    false_vals = ['no', 'n']
     try:
         val = val.lower()
     except AttributeError:
         val = str(val).lower()
-    if val in ('y', 'yes', 't', 'true', 'on', '1', '', None):
-        return 1
-    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
-        return 0
+    if val in true_vals:
+        return True
+    elif val in false_vals:
+        return False
     else:
-        raise ValueError("invalid input value: %r" % (val,))
+        raise ValueError("Invalid input value: %s" % val)
+
 
 
 # =============================================================================

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -4,14 +4,14 @@ from ice_setup import strtobool, prompt, prompt_bool
 
 def true_responses(upper_casing=False):
     if upper_casing:
-        return ['Y', 1, '1', 'YES', 'ON', '']
-    return ['y', 1, '1', 'yes', 'on', '']
+        return ['Y', 'YES', '']
+    return ['y', 'yes', '']
 
 
 def false_responses(upper_casing=False):
     if upper_casing:
-        return ['N', 0, '0', 'NO', 'OFF']
-    return ['n', 0, '0', 'no', 'off']
+        return ['N', 'NO']
+    return ['n', 'no']
 
 
 def invalid_responses():
@@ -22,19 +22,19 @@ class TestStrToBool(object):
 
     @pytest.mark.parametrize('response', true_responses())
     def test_trueish(self, response):
-        assert strtobool(response) == 1
+        assert strtobool(response) is True
 
     @pytest.mark.parametrize('response', false_responses())
     def test_falseish(self, response):
-        assert strtobool(response) == 0
+        assert strtobool(response) is False
 
     @pytest.mark.parametrize('response', true_responses(True))
     def test_trueish_upper(self, response):
-        assert strtobool(response) == 1
+        assert strtobool(response) is True
 
     @pytest.mark.parametrize('response', false_responses(True))
     def test_falseish_upper(self, response):
-        assert strtobool(response) == 0
+        assert strtobool(response) is False
 
     @pytest.mark.parametrize('response', invalid_responses())
     def test_invalid(self, response):
@@ -48,25 +48,25 @@ class TestPromptBool(object):
     def test_trueish(self, response):
         fake_input = lambda x: response
         qx = 'what the what?'
-        assert prompt_bool(qx, _raw_input=fake_input) == 1
+        assert prompt_bool(qx, _raw_input=fake_input) is True
 
     @pytest.mark.parametrize('response', false_responses())
     def test_falseish(self, response):
         fake_input = lambda x: response
         qx = 'what the what?'
-        assert prompt_bool(qx, _raw_input=fake_input) == 0
+        assert prompt_bool(qx, _raw_input=fake_input) is False
 
     def test_try_again_true(self):
-        responses = ['g', 'h', 1]
+        responses = ['g', 'h', 'y']
         fake_input = lambda x: responses.pop(0)
         qx = 'what the what?'
-        assert prompt_bool(qx, _raw_input=fake_input) == 1
+        assert prompt_bool(qx, _raw_input=fake_input) is True
 
     def test_try_again_false(self):
-        responses = ['g', 'h', 0]
+        responses = ['g', 'h', 'n']
         fake_input = lambda x: responses.pop(0)
         qx = 'what the what?'
-        assert prompt_bool(qx, _raw_input=fake_input) == 0
+        assert prompt_bool(qx, _raw_input=fake_input) is False
 
 
 class TestPrompt(object):


### PR DESCRIPTION
Should take care of http://tracker.ceph.com/issues/10558

Create a simpler strtobool that just looks for yes/no combinations
rather than also allowing numbers ('1', '0') or things like "on"
or "off".  This allows us to remove the previous PSFL code.

Make sure that we maintain the previous behavior where not entering
a response to the prompt evaluates to True.  True is the default
value for an empty string.

Update tests to account for new behavior.

Signed-off-by: Travis Rhoden trhoden@redhat.com
