### PR TITLE
Fix Yum and Apt repo creation tests

### DIFF
--- a/ice_setup/tests/test_distributions.py
+++ b/ice_setup/tests/test_distributions.py
@@ -17,37 +17,37 @@ def etc_path():
 class TestYum(object):
 
     def test_creates_default_file(self, etc_path):
-        Yum.create_repo_file('repo_url', 'gpg_url', etc_path=etc_path)
+        Yum.create_repo_file('ceph', 'repo_url', 'gpg_url', etc_path=etc_path)
         assert os.path.isfile(os.path.join(etc_path, 'ice.repo'))
 
     def test_gpg_url_default_file(self, etc_path):
-        Yum.create_repo_file('repo_url', 'gpg_url', etc_path=etc_path)
+        Yum.create_repo_file('ceph', 'repo_url', 'gpg_url', etc_path=etc_path)
         repo_file_path = os.path.join(etc_path, 'ice.repo')
         with open(repo_file_path) as contents:
             contents = contents.read()
         assert 'gpg_url' in contents
 
     def test_repo_url_default_file(self, etc_path):
-        Yum.create_repo_file('/opt/ICE/repo', 'gpg_url', etc_path=etc_path)
+        Yum.create_repo_file('ceph', '/opt/ICE/repo', 'gpg_url', etc_path=etc_path)
         repo_file_path = os.path.join(etc_path, 'ice.repo')
         with open(repo_file_path) as contents:
             contents = contents.read()
         assert '/opt/ICE/repo' in contents
 
     def test_creates_custom_file(self, etc_path):
-        Yum.create_repo_file('repo_url', 'gpg_url', file_name='foo', etc_path=etc_path)
-        assert os.path.isfile(os.path.join(etc_path, 'foo'))
+        Yum.create_repo_file('ceph', 'repo_url', 'gpg_url', file_name='foo', etc_path=etc_path)
+        assert os.path.isfile(os.path.join(etc_path, 'foo.repo'))
 
     def test_gpg_url_custom_file(self, etc_path):
-        Yum.create_repo_file('repo_url', 'gpg_url', file_name='foo', etc_path=etc_path)
-        repo_file_path = os.path.join(etc_path, 'foo')
+        Yum.create_repo_file('ceph', 'repo_url', 'gpg_url', file_name='foo', etc_path=etc_path)
+        repo_file_path = os.path.join(etc_path, 'foo.repo')
         with open(repo_file_path) as contents:
             contents = contents.read()
         assert 'gpg_url' in contents
 
     def test_repo_url_custom_file(self, etc_path):
-        Yum.create_repo_file('/opt/ICE/repo', 'gpg_url', file_name='foo',  etc_path=etc_path)
-        repo_file_path = os.path.join(etc_path, 'foo')
+        Yum.create_repo_file('ceph', '/opt/ICE/repo', 'gpg_url', file_name='foo',  etc_path=etc_path)
+        repo_file_path = os.path.join(etc_path, 'foo.repo')
         with open(repo_file_path) as contents:
             contents = contents.read()
         assert '/opt/ICE/repo' in contents
@@ -56,37 +56,37 @@ class TestYum(object):
 class TestApt(object):
 
     def test_creates_default_file(self, etc_path):
-        Apt.create_repo_file('repo_url', 'gpg_url', etc_path=etc_path, codename='saucy')
+        Apt.create_repo_file('ceph', 'repo_url', 'gpg_url', etc_path=etc_path, codename='saucy')
         assert os.path.isfile(os.path.join(etc_path, 'ice.list'))
 
     def test_gpg_url_default_file(self, etc_path):
-        Apt.create_repo_file('repo_url', 'gpg_url', etc_path=etc_path, codename='saucy')
+        Apt.create_repo_file('ceph', 'repo_url', 'gpg_url', etc_path=etc_path, codename='saucy')
         repo_file_path = os.path.join(etc_path, 'ice.list')
         with open(repo_file_path) as contents:
             contents = contents.read()
         assert 'repo_url' in contents
 
     def test_repo_url_default_file(self, etc_path):
-        Apt.create_repo_file('/opt/ICE/repo', 'gpg_url', etc_path=etc_path, codename='saucy')
+        Apt.create_repo_file('ceph', '/opt/ICE/repo', 'gpg_url', etc_path=etc_path, codename='saucy')
         repo_file_path = os.path.join(etc_path, 'ice.list')
         with open(repo_file_path) as contents:
             contents = contents.read()
         assert '/opt/ICE/repo' in contents
 
     def test_creates_custom_file(self, etc_path):
-        Apt.create_repo_file('repo_url', 'gpg_url', file_name='foo', etc_path=etc_path, codename='saucy')
-        assert os.path.isfile(os.path.join(etc_path, 'foo'))
+        Apt.create_repo_file('ceph', 'repo_url', 'gpg_url', file_name='foo', etc_path=etc_path, codename='saucy')
+        assert os.path.isfile(os.path.join(etc_path, 'foo.list'))
 
     def test_gpg_url_custom_file(self, etc_path):
-        Apt.create_repo_file('repo_url', 'gpg_url', file_name='foo', etc_path=etc_path, codename='saucy')
-        repo_file_path = os.path.join(etc_path, 'foo')
+        Apt.create_repo_file('ceph', 'repo_url', 'gpg_url', file_name='foo', etc_path=etc_path, codename='saucy')
+        repo_file_path = os.path.join(etc_path, 'foo.list')
         with open(repo_file_path) as contents:
             contents = contents.read()
         assert 'repo_url' in contents
 
     def test_repo_url_custom_file(self, etc_path):
-        Apt.create_repo_file('/opt/ICE/repo', 'gpg_url', file_name='foo',  etc_path=etc_path, codename='saucy')
-        repo_file_path = os.path.join(etc_path, 'foo')
+        Apt.create_repo_file('ceph', '/opt/ICE/repo', 'gpg_url', file_name='foo',  etc_path=etc_path, codename='saucy')
+        repo_file_path = os.path.join(etc_path, 'foo.list')
         with open(repo_file_path) as contents:
             contents = contents.read()
         assert '/opt/ICE/repo' in contents


### PR DESCRIPTION
The call to create_repo_file() was missing it's first argument,
the name of the template to use.

The tests for a custom repo file name were not using the correct
file suffixe (.repo or .list)

Signed-off-by: Travis Rhoden trhoden@redhat.com
