### PR TITLE
Run ice_setup from anywhere on filesystem

### DIFF
--- a/ice_setup/tests/test_paths.py
+++ b/ice_setup/tests/test_paths.py
@@ -1,0 +1,38 @@
+import tempfile
+import os
+import shutil
+
+import pytest
+
+from ice_setup.ice import get_package_source, DirNotFound, VersionNotFound
+
+
+@pytest.fixture
+def pkg_path():
+    pkg_path = tempfile.mkdtemp()
+
+    def fin():
+        shutil.rmtree(pkg_path)
+    return pkg_path
+
+
+class TestGetPackageSource(object):
+
+    def test_unversioned_missing(self, pkg_path):
+        with pytest.raises(DirNotFound):
+            get_package_source(pkg_path, 'ceph')
+
+    def test_unversioned_ok(self, pkg_path):
+        os.mkdir(os.path.join(pkg_path, 'ceph'))
+        path = get_package_source(pkg_path, 'ceph')
+        assert path == os.path.join(pkg_path, 'ceph')
+
+    def test_versioned_missing(self, pkg_path):
+        os.mkdir(os.path.join(pkg_path, 'ceph'))
+        with pytest.raises(VersionNotFound):
+            get_package_source(pkg_path, 'ceph', traverse=True)
+
+    def test_versioned_ok(self, pkg_path):
+        os.makedirs(os.path.join(pkg_path, 'ceph/0.80.0'))
+        path = get_package_source(pkg_path, 'ceph', traverse=True)
+        assert path == os.path.join(pkg_path, 'ceph/0.80.0')


### PR DESCRIPTION
This enhances the ice_setup script to accept a -d/--dir option
that contains the path to where the script should look for package
files to add to the locally hosted repos.

Previously, the script only looked in the same directory as the
script (which may not even be the CWD). To preserve backwards
compatibility, --dir is optional.  If not provided, the default path
is now the CWD.  When run without any subcommands (i.e. 'ice-setup'),
the interactive prompts show the user the path to search, and allow
the user to modify it.  providing --dir to the script merely changes
this default.

I found a lot of the terminology confusing -- referring to the
sources as "repos" when they are not actually repos.  They are folders
of package files that should be used to create a formal repo. I've
changed many of the function and variable names to reflect that.

The Configure subcommands are there to allow a user to update/copy
new package files into the ICE node repositories, without going
through the interactive prompts. The user can pick the repos
for local use (calamari-server, ceph-deploy) or remote use (ceph,
calamari-clients), or all.

This functionality was broken previously because the calls to
configure_[local,remote] were missing the needed names.

The configure commands already accepted a path to grab the package files
from, but the path is optional. no dash or double-dash is needed for the
path, and if not given then CWD is used for the path.

Enhance get_package_source to know the difference between a top-level
folder not existing (i.e. 'ceph') and the versioned folder when it is
expected (i.e. 'ceph/0.80'). Explicity check that the paths are
directories, not just the path exists.

Since os.walk is returning a list of directories, and we are using an
entry from that list, there is no reason to check that it is a directory
once again.

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1179955