### PR TITLE
Optionally disable GPG repo checking and/or key import

### DIFF
--- a/ice_setup/ice.py
+++ b/ice_setup/ice.py
@@ -474,6 +474,7 @@ master = {master}
 name=Calamari
 baseurl={minion_url}
 gpgkey={minion_gpg_url}
+gpgcheck={gpg_check}
 enabled=1
 priority=1
 proxy=_none_
@@ -482,6 +483,7 @@ proxy=_none_
 name=Ceph
 baseurl={ceph_url}
 gpgkey={ceph_gpg_url}
+gpgcheck={gpg_check}
 default=true
 priority=1
 proxy=_none_
@@ -1217,7 +1219,7 @@ def configure_remote(
 
 
 def configure_ceph_deploy(master, minion_url, minion_gpg_url,
-                          ceph_url, ceph_gpg_url):
+                          ceph_url, ceph_gpg_url, use_gpg=True):
     """
     Write the ceph-deploy conf to automagically tell ceph-deploy to use
     the right repositories and flags without making the user specify them
@@ -1241,6 +1243,7 @@ def configure_ceph_deploy(master, minion_url, minion_gpg_url,
                 minion_gpg_url=minion_gpg_url,
                 ceph_url=ceph_url,
                 ceph_gpg_url=ceph_gpg_url,
+                gpg_check=1 if use_gpg else 0,
             )
 
             rc_file.write(contents)

--- a/ice_setup/ice.py
+++ b/ice_setup/ice.py
@@ -421,10 +421,10 @@ ceph_deploy_yum_template = """
 name=ceph_deploy packages for $basearch
 baseurl={repo_url}
 enabled=1
-gpgcheck=1
 type=rpm-md
 priority=1
 gpgkey={gpg_url}
+gpgcheck={gpg_check}
 """
 
 calamari_yum_template = """
@@ -432,19 +432,20 @@ calamari_yum_template = """
 name=calamari packages for $basearch
 baseurl={repo_url}
 enabled=1
-gpgcheck=1
 type=rpm-md
 priority=1
 gpgkey={gpg_url}
+gpgcheck={gpg_check}
 """
 
 ceph_yum_template = """
 [ceph]
 name=Ceph
 baseurl={repo_url}
-gpgkey={gpg_url}
 default=true
 priority=1
+gpgkey={gpg_url}
+gpgcheck={gpg_check}
 proxy=_none_
 """
 
@@ -562,7 +563,7 @@ def append_item_or_list(list_, append):
 class Yum(object):
 
     @classmethod
-    def create_repo_file(cls, template_name, repo_url, gpg_url, file_name=None, **kw):
+    def create_repo_file(cls, template_name, repo_url, gpg_url, file_name=None, use_gpg=True, **kw):
         """set the contents of /etc/yum.repos.d/ice.repo"""
         etc_path = kw.pop('etc_path', '/etc/yum.repos.d')
         file_name = '%s.repo' % (file_name or 'ice')
@@ -572,16 +573,21 @@ class Yum(object):
             contents = template.format(
                 gpg_url=gpg_url,
                 repo_url=repo_url,
+                gpg_check=1 if use_gpg else 0,
             )
             repo_file.write(contents)
 
     @classmethod
-    def print_repo_file(cls, template_name, repo_url, gpg_url, file_name=None, **kw):
+    def print_repo_file(cls, template_name, repo_url, gpg_url, file_name=None, use_gpg=True, **kw):
         """print repo file as it would be written to yum.repos.d"""
         template = yum_templates[template_name]
         logger.info('Contents of %s repo file:' % template_name)
-        logger.info(template.format(
-            gpg_url=gpg_url, repo_url=repo_url)
+        logger.info(
+            template.format(
+                gpg_url=gpg_url,
+                repo_url=repo_url,
+                gpg_check=1 if use_gpg else 0,
+            )
         )
 
     @classmethod

--- a/ice_setup/ice.py
+++ b/ice_setup/ice.py
@@ -76,6 +76,11 @@ VERBOSE_COLOR_FORMAT = "[%(name)s][$BOLD%(levelname)s] $RESET%(color_levelname)s
 CWD = os.getcwd()
 
 
+def get_rhel_gpg_path():
+    gpg_path = "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+    return 'file://%s' % gpg_path
+
+
 def color_message(message):
     message = message.replace("$RESET", RESET_SEQ).replace("$BOLD", BOLD_SEQ)
     return message

--- a/ice_setup/ice.py
+++ b/ice_setup/ice.py
@@ -585,7 +585,7 @@ class Yum(object):
         )
 
     @classmethod
-    def import_repo(cls, gpg_path):
+    def import_repo_key(cls, gpg_path):
         """
         import the gpg key so that the repo is fully validated
         """
@@ -654,7 +654,7 @@ class Apt(object):
         )
 
     @classmethod
-    def import_repo(cls, gpg_path):
+    def import_repo_key(cls, gpg_path):
         """
         import the gpg key so that the repo is fully validated
         """
@@ -1281,7 +1281,7 @@ def configure_local(name, package_path):
         codename=distro.codename,
     )
 
-    distro.pkg_manager.import_repo(
+    distro.pkg_manager.import_repo_key(
         gpg_path,
     )
 


### PR DESCRIPTION
On RHEL, there is never any need to import a GPG key to yum.  the RHEL signing key is already there.

For QA purposes, we need the ability to configure yum repos that disable gpgcheck.  To do that, add a `--no-gpg` switch to ice-setup that will disable gpgcheck in Yum repos.

Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1193745

I tested this on CentOS and RHEL7 and got the desired effect.  This should still work fine when using Inktank signed packages on CentOS, but has no effect for on Debian based distros.