### PR TITLE
Add RPM sync functionality for RH CDN

### DIFF
--- a/ice_setup/ice.py
+++ b/ice_setup/ice.py
@@ -623,17 +623,17 @@ class Yum(object):
     @classmethod
     def sync(cls, repos):
         # resolve needed dependencies
-        if not which('syncrepo'):
-            self.install('yum-utils')
+        if not which('reposync'):
+            cls.install('yum-utils')
         if not which('createrepo'):
-            self.install('createrepo')
+            cls.install('createrepo')
 
         # infer the path to the ceph repo by looking at cephdeploy.conf because
         # we never overwrite ceph, rather, we rely on versions so the path for
         # ceph can have multiple versions already, like ``static/ceph/0.80``
         # and ``static/ceph/0.86``
         destinations = {
-            'ceph' : infer_ceph_repo(),
+            'ceph': infer_ceph_repo(),
             'ceph-deploy': '/opt/ICE/ceph-deploy',
             'calamari': '/opt/ICE/calamari-server',
         }
@@ -658,6 +658,8 @@ class Yum(object):
                 ]
             )
 
+            run(['createrepo', destination ])
+            run(['yum', 'clean', 'all'])
 
     @classmethod
     def enumerate_repo(cls, path):
@@ -1105,7 +1107,7 @@ def infer_ceph_repo():
     parser.read(config)
 
     try:
-        http_path = parser.get(section, key)
+        http_path = parser.get('ceph', 'baseurl')
     except (NoSectionError, NoOptionError):
         msg = 'could not find a ``ceph`` repo section at %s' % config
         raise ICEError(msg)

--- a/ice_setup/ice.py
+++ b/ice_setup/ice.py
@@ -1451,7 +1451,8 @@ def default(package_path, use_gpg):
         '1. Configure the ICE Node (current host) as a repository Host',
         '2. Install Calamari web application on the ICE Node (current host)',
         '3. Install ceph-deploy on the ICE Node (current host)',
-        '4. Configure host as a ceph and calamari minion repository for remote hosts',
+        '4. Configure host as a Ceph repository for remote hosts',
+        '5. Configure host as a Calamari minion repository for remote hosts',
     ]
 
     logger.info('this script will setup Calamari, package repo, and ceph-deploy')
@@ -1584,8 +1585,7 @@ def interactive_help(mode='interactive mode'):
 class UpdateRepo(object):
 
     _help = dedent("""
-    Connects to hosted repositories and fetches updates to packages for the
-    local repos.
+    Updates local repositories by synchronizing with remote update repositories.
 
     Commands:
 

--- a/ice_setup/ice.py
+++ b/ice_setup/ice.py
@@ -635,14 +635,12 @@ class Yum(object):
         # and ``static/ceph/0.86``
         destinations = {
             'ceph': infer_ceph_repo(),
-            'ceph-deploy': '/opt/ICE/ceph-deploy',
-            'calamari': '/opt/ICE/calamari-server',
+            'calamari-minions': '/opt/calamari/webapp/content/calamari-minions',
         }
 
         repo_ids = {
-            'ceph-deploy': 'Server-RH7-CEPH-INSTALLER-1.2',
             'ceph': 'Server-RH7-CEPH-1.2',
-            'calamari': 'Server-RH7-CEPH-CALAMARI-1.2'
+            'calamari-minions': 'Server-RH7-CEPH-CALAMARI-1.2'
         }
 
         for repo in repos:
@@ -1620,13 +1618,12 @@ class UpdateRepo(object):
     Commands:
 
       all         Updates all repositories configured for this host
-                  (ceph, ceph-deploy, and calamari)
+                  (ceph and calamari-minions)
 
     Optional Arguments:
 
       ceph              Update the ceph repo
-      ceph-deploy       Update the ceph-deploy repo
-      calamari-server   Update the calamari repo
+      calamari-minions  Update the calamari-minions repo
 
     Examples:
 
@@ -1634,18 +1631,14 @@ class UpdateRepo(object):
 
       ice_setup update all
 
-    Update the calamari and ceph-deploy repos:
+    Update just the ceph repo:
 
-      ice_setup update ceph-deploy calamari
-
-    Update just the ceph-deploy repo:
-
-      ice_setup update ceph-deploy
+      ice_setup update ceph
     """)
 
     def __init__(self, argv):
         self.argv = argv
-        self.optional_arguments = ['ceph', 'ceph-deploy', 'calamari']
+        self.optional_arguments = ['ceph', 'calamari-minions']
 
     def parse_args(self):
         options = ['all']

--- a/ice_setup/ice.py
+++ b/ice_setup/ice.py
@@ -1636,10 +1636,11 @@ class UpdateRepo(object):
 
 def update_repo(repos):
     distro = get_distro()
-    if len(repos) == 1:
-        logger.debug('updating repo: %s' % repos)
-    else:
-        logger.debug('updating repos: %s' % ' '.join(repos))
+    logger.debug('updating repo%s: %s' % (
+        's' if len(repos) > 1 else '',
+        ' '.join(repos)
+        )
+    )
     distro.pkg_manager.sync(repos)
 
 # =============================================================================

--- a/ice_setup/ice.py
+++ b/ice_setup/ice.py
@@ -1291,6 +1291,8 @@ class Configure(object):
             configure_remote('ceph', package_path, versioned=True)
             configure_remote('calamari-minions', package_path)
 
+        return True
+
 
 def fqdn_with_protocol():
     """
@@ -1676,6 +1678,8 @@ class UpdateRepo(object):
                     error_msg = "Unrecognized repo name(s) given: %s" % (", ".join(frozenset(parser.arguments).difference(self.optional_arguments)))
                     raise InvalidRepoName(error_msg)
 
+        return True
+
 
 def update_repo(repos):
     distro = get_distro()
@@ -1750,11 +1754,12 @@ def _main(argv=None):
     # parse first with no help; set defaults later
     parser.catch_version = __version__
     parser.catch_help = ice_help()
-    parser.dispatch()
+    subcmds = parser.dispatch()
 
     # when no subcommands are passed in, just use our default routine
-    sudo_check()
-    default(parser.get('-d', CWD), not parser.has(('--no-gpg')))
+    if not subcmds:
+        sudo_check()
+        default(parser.get('-d', CWD), not parser.has(('--no-gpg')))
 
 def main():
     # This try/except dance *just* for KeyboardInterrupt is horrible but there

--- a/ice_setup/ice.py
+++ b/ice_setup/ice.py
@@ -1091,8 +1091,8 @@ def which(executable):
             return executable_path
 
 
-def infer_ceph_repo():
-    configs = get_ceph_deploy_conf_paths()
+def infer_ceph_repo(_configs=None):
+    configs = _configs or get_ceph_deploy_conf_paths()
     config = None
     for conf in configs:
         if os.path.exists(conf):

--- a/ice_setup/ice.py
+++ b/ice_setup/ice.py
@@ -1463,12 +1463,69 @@ def interactive_help(mode='interactive mode'):
     prompt_continue()
 
 
+class UpdateRepo(object):
+
+    _help = dedent("""
+    Connects to hosted repositories and fetches updates to packages for the
+    local repos.
+
+    Commands:
+
+      all         Updates all repositories configured for this host
+                  (ceph, ceph-deploy, and calamari)
+
+    Optional Arguments:
+
+      ceph              Update the ceph repo
+      ceph-deploy       Update the ceph-deploy repo
+      calamari-server   Update the calamari repo
+
+    Examples:
+
+    Update all of the repos available:
+
+      ice_setup update all
+
+    Update the calamari and ceph-deploy repos:
+
+      ice_setup update ceph-deploy calamari
+
+    Update just the ceph-deploy repo:
+
+      ice_setup update ceph-deploy
+    """)
+
+    def __init__(self, argv):
+        self.argv = argv
+        self.optional_arguments = ['ceph', 'ceph-deploy', 'calamari']
+
+    def parse_args(self):
+        options = ['all']
+        parser = Transport(self.argv, options=options)
+        parser.catch_help = self._help
+        parser.parse_args()
+
+        #sudo_check()
+
+        if parser.has('all'):
+            update_repo(self.optional_arguments)
+        else:
+            if parser.arguments:
+                update_repo(
+                    [i for i in parser.arguments if i in self.optional_arguments]
+                )
+
+
+def update_repo(repos):
+    pass
+
 # =============================================================================
 # Main
 # =============================================================================
 
 command_map = {
     'configure': Configure,
+    'update': UpdateRepo,
 }
 
 
@@ -1486,6 +1543,7 @@ def ice_help():
     Subcommands:
 
       configure         Configuration of the ICE node
+      update            Update local repositories from hosted repos.
     """
     return '%s\n%s\n%s\n%s' % (
         help_header,

--- a/ice_setup/ice.py
+++ b/ice_setup/ice.py
@@ -1752,10 +1752,6 @@ def _main(argv=None):
     parser.catch_help = ice_help()
     parser.dispatch()
 
-    # if dispatch did not catch anything now, parse help
-    parser.catches_help()
-    parser.catches_version()
-
     # when no subcommands are passed in, just use our default routine
     sudo_check()
     default(parser.get('-d', CWD), not parser.has(('--no-gpg')))

--- a/ice_setup/tests/test_system.py
+++ b/ice_setup/tests/test_system.py
@@ -1,8 +1,23 @@
-from ice_setup.ice import get_fqdn
+import os
+import tempfile
+from pytest import raises
+import pytest
+from textwrap import dedent
+from ice_setup.ice import get_fqdn, infer_ceph_repo, ICEError, DirNotFound
 
 
 class FakeSocket(object):
     pass
+
+
+@pytest.fixture
+def cephdeploy_conf():
+    path = tempfile.mkstemp()
+
+    def fin():
+        os.remove(path)
+
+    return path[-1]
 
 
 class TestGetFQDN(object):
@@ -21,3 +36,36 @@ class TestGetFQDN(object):
     def test_valid_fqdn(self):
         self.sock.getfqdn = lambda: 'zombo.com'
         assert get_fqdn(_socket=self.sock) == 'zombo.com'
+
+
+class TestInferCephRepo(object):
+
+    def test_does_not_find_cephdeployconf(self):
+        with raises(DirNotFound):
+            infer_ceph_repo(_configs=[''])
+
+    def test_does_not_find_a_ceph_repo_section(self, cephdeploy_conf):
+        with raises(ICEError):
+            infer_ceph_repo(_configs=[cephdeploy_conf])
+
+    def test_does_find_a_ceph_repo_section(self, cephdeploy_conf):
+        print cephdeploy_conf
+
+        with open(cephdeploy_conf, 'w') as f:
+            f.write(dedent("""
+            [ceph]
+            baseurl=http://fqdn/static/ceph/0.80
+            """))
+        result = infer_ceph_repo(_configs=[cephdeploy_conf])
+        assert result == '/opt/calamari/webapp/content/ceph/0.80'
+
+    def test_deals_with_non_trailing_slashes(self, cephdeploy_conf):
+        print cephdeploy_conf
+
+        with open(cephdeploy_conf, 'w') as f:
+            f.write(dedent("""
+            [ceph]
+            baseurl=http://fqdn/static/ceph/0.80/
+            """))
+        result = infer_ceph_repo(_configs=[cephdeploy_conf])
+        assert result == '/opt/calamari/webapp/content/ceph/0.80'


### PR DESCRIPTION
Add the option to update the locally-hosted `ceph` and `calamari-minions` repositories with the RH CDN.

This assumes that a user has already enabled the repos using `subscription-manager` on their Ceph admin node.  If the user does indeed have access to the repos on the CDN, running `ice_setup update ...` will pull down any updates that have been pushed via the CDN, and regenerate the locally-hosted repos for use by internal Ceph nodes.

The Ceph nodes that grab their updates from the Ceph admin node are *not* updated automatically.  The Ceph and minion packages still have to be updated via `ceph-deploy`, which is not a change in functionality.

Ref: http://tracker.ceph.com/issues/9686
Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1165309
Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1165312