### PR TITLE
clarify HTTPS prompt

### DIFF
--- a/ice_setup/ice.py
+++ b/ice_setup/ice.py
@@ -1148,7 +1148,7 @@ def fqdn_with_protocol():
         return fqdn_with_protocol()
 
     protocol = prompt(
-        'what protocol would this host use (http or https)?',
+        'If you have manually configured your Calamari web server for HTTPS, select \'https\', otherwise select the default \'http\'',
         default='http',
         lowercase=True,
     )


### PR DESCRIPTION
If a user selects "https" at the prompt, we require that the user has pre-configured Apache to serve HTTPS.

Prior to this commit, it was not clear to users that they must set up HTTPS by hand prior to running ice_setup.

Adjust the prompt so that it is clear that HTTPS setup must be done manually, and place a stronger emphasis on choosing the "http" default.

See https://bugzilla.redhat.com/1197883 for the original report.