### PR TITLE
write proper program name in cephdeploy.conf comment

### DIFF
--- a/ice_setup/ice.py
+++ b/ice_setup/ice.py
@@ -463,7 +463,7 @@ ceph_deploy_apt_template = """deb {repo_url} {codename} main\n"""
 
 
 ceph_deploy_rc = """
-# This file was automatically generated after ice_setup.py was run. It provides
+# This file was automatically generated after ice_setup was run. It provides
 # the repository url and GPG information so that ceph-deploy can install the
 # repositories in remote hosts.
 #


### PR DESCRIPTION
Now that ice_setup is a real package, the command that users run is `ice_setup`, not `ice_setup.py`.

Prior to this commit, the boilerplate comment text in cephdeploy.conf contained the old "ice_setup.py" name. Fix this to reflect the updated program name.