### PR TITLE
require pkg_resources module at runtime

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ X-Python-Version: >=2.6
 
 Package: ice-setup
 Architecture: all
-Depends: ${misc:Depends}, ${python:Depends}
+Depends: ${misc:Depends}, ${python:Depends}, python-pkg-resources
 Description: Setup script for Red Hat Ceph
  A standalone setup script to install and configure different services for Ceph
  like Calamari, ceph-deploy and package repositories.

--- a/ice_setup.spec
+++ b/ice_setup.spec
@@ -19,6 +19,7 @@ URL:            https://github.com/ceph/ice-setup
 # 3. git checkout <the version you want>
 # 4. python setup.py sdist
 Source0:        %{name}-%{version}.tar.gz
+Requires:       python-setuptools
 BuildArch:      noarch
 BuildRequires:  python-devel
 BuildRequires:  python-setuptools


### PR DESCRIPTION
The `/usr/bin/ice_setup` utility uses load_entry_point from the `pkg_resources` module. If this module is not available, `/usr/bin/ice_setup` will crash.

Require the OS packages that include `pkg_resources` so that this dependency is available at runtime.

There were some scenarios where the `python-setuptools` package (on Red Hat) or `python-pkg-resources` package (on Ubuntu) was unavailable (for example, in minimal OS installs).

Refs: https://bugzilla.redhat.com/1212045