### PR TITLE
remove `default` keys from repo files

### DIFF
--- a/ice_setup/ice.py
+++ b/ice_setup/ice.py
@@ -448,7 +448,6 @@ ceph_osd_yum_template = """
 [ceph-osd]
 name=Ceph-OSD
 baseurl={repo_url}
-default=true
 priority=1
 gpgcheck={gpg_check}
 proxy=_none_
@@ -457,7 +456,6 @@ ceph_mon_yum_template = """
 [ceph-mon]
 name=Ceph-MON
 baseurl={repo_url}
-default=true
 priority=1
 gpgkey={gpg_url}
 gpgcheck={gpg_check}
@@ -492,7 +490,6 @@ name=Ceph-MON
 baseurl={ceph_mon_url}
 gpgkey={ceph_mon_gpg_url}
 gpgcheck={gpg_check}
-default=true
 priority=1
 proxy=_none_
 
@@ -501,7 +498,6 @@ name=Ceph-OSD
 baseurl={ceph_osd_url}
 gpgkey={ceph_osd_gpg_url}
 gpgcheck={gpg_check}
-default=true
 priority=1
 proxy=_none_
 

--- a/ice_setup/ice.py
+++ b/ice_setup/ice.py
@@ -428,7 +428,6 @@ name=ceph_deploy packages for $basearch
 baseurl={repo_url}
 enabled=1
 type=rpm-md
-priority=1
 gpgkey={gpg_url}
 gpgcheck={gpg_check}
 """
@@ -439,7 +438,6 @@ name=calamari packages for $basearch
 baseurl={repo_url}
 enabled=1
 type=rpm-md
-priority=1
 gpgkey={gpg_url}
 gpgcheck={gpg_check}
 """
@@ -448,7 +446,6 @@ ceph_osd_yum_template = """
 [ceph-osd]
 name=Ceph-OSD
 baseurl={repo_url}
-priority=1
 gpgcheck={gpg_check}
 proxy=_none_
 """
@@ -456,7 +453,6 @@ ceph_mon_yum_template = """
 [ceph-mon]
 name=Ceph-MON
 baseurl={repo_url}
-priority=1
 gpgkey={gpg_url}
 gpgcheck={gpg_check}
 proxy=_none_
@@ -490,7 +486,6 @@ name=Ceph-MON
 baseurl={ceph_mon_url}
 gpgkey={ceph_mon_gpg_url}
 gpgcheck={gpg_check}
-priority=1
 proxy=_none_
 
 [ceph-osd]
@@ -498,7 +493,6 @@ name=Ceph-OSD
 baseurl={ceph_osd_url}
 gpgkey={ceph_osd_gpg_url}
 gpgcheck={gpg_check}
-priority=1
 proxy=_none_
 
 """

--- a/ice_setup/ice.py
+++ b/ice_setup/ice.py
@@ -1538,13 +1538,19 @@ def default(package_path, use_gpg):
     logger.info('    calamari-ctl initialize')
     logger.info('')
 
-    logger.info('To install the repo files on remote nodes with ceph-deploy, run:')
-    logger.info('    ceph-deploy install --repo {HOSTS}')
+    logger.info('To install the ceph-osd repo files on remote nodes with ceph-deploy, run:')
+    logger.info('    ceph-deploy install --repo --release=ceph-osd {HOSTS}')
+    logger.info('')
+    logger.info('To install the ceph-mon repo files on remote nodes with ceph-deploy, run:')
+    logger.info('    ceph-deploy install --repo --release=ceph-mon {HOSTS}')
     logger.info('')
     logger.warning('If upgrading, `ceph-deploy install {HOSTS}` will also upgrade ceph on remote nodes')
     logger.info('')
-    logger.info('To install ceph on remote nodes with ceph-deploy, run:')
-    logger.info('    ceph-deploy install {HOSTS}')
+    logger.info('To install ceph OSD on remote nodes with ceph-deploy, run:')
+    logger.info('    ceph-deploy install --osd {HOSTS}')
+    logger.info('')
+    logger.info('To install ceph MON on remote nodes with ceph-deploy, run:')
+    logger.info('    ceph-deploy install --mon {HOSTS}')
     logger.info('')
 
 


### PR DESCRIPTION
So that a user will need to explicitly enable/install them (otherwise it will just pick one)

This also updates the output when an install completes with the new components and examples
on how to install an osd or a mon.

https://bugzilla.redhat.com/show_bug.cgi?id=1223149