### PR TITLE
Update to 0.3.2 to encompass package version updates

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+ice-setup (0.3.2) unstable; urgency=low
+
+  * incorporate 0.3.1
+  * add bump of versions in packaging files
+
+ -- Dan Mick <dan.mick@redhat.com>  Tue, 09 Jun 2015 18:56:08 -0700
+
 ice-setup (0.3.0-2) unstable; urgency=low
 
   * stamp with packaging info, modify to native package

--- a/ice_setup.spec
+++ b/ice_setup.spec
@@ -7,7 +7,7 @@
 %endif
 
 Name:           ice_setup
-Version:        0.3.0
+Version:        0.3.2
 Release:        1%{?dist}
 Summary:        Red Hat Ceph Storage setup tool
 Group:          System Environment/Base

--- a/ice_setup/ice.py
+++ b/ice_setup/ice.py
@@ -36,7 +36,7 @@ from ConfigParser import SafeConfigParser, NoSectionError, NoOptionError
 from functools import wraps
 from textwrap import dedent
 
-__version__ = '0.3.1'
+__version__ = '0.3.2'
 
 help_header = """
 


### PR DESCRIPTION
0.3.1 is in the Python code, but that doesn't influence the package versions.  Get them too,
and update to 0.3.2