### PR TITLE
Setup Apt Pinning for local RHCS repos

### DIFF
--- a/ice_setup/ice.py
+++ b/ice_setup/ice.py
@@ -785,6 +785,15 @@ class Debian(object):
     pkg_manager = Apt()
 
 
+def pin_local_repos(path='/etc/apt/preferences.d/rhcs.pref'):
+    template = ("Explanation: Prefer Red Hat packages\n"
+                "Package: *\n"
+                "Pin: release o=/Red Hat/\n"
+                "Pin-Priority: 999\n")
+    with open(path, 'wb') as fout:
+        fout.write(template)
+
+
 # Normalize casing for easier mapping
 centos = CentOS
 debian = Debian
@@ -1245,12 +1254,14 @@ class Configure(object):
             configure_local('Tools', package_path)
             configure_remote('ceph-osd', package_path)
             configure_remote('ceph-mon', package_path)
+            pin_local_repos()
 
         elif parser.has('local'):
             package_path = parser.get('local')
             configure_local('Calamari', package_path)
             configure_local('Installer', package_path)
             configure_local('Tools', package_path)
+            pin_local_repos()
 
         elif parser.has('remote'):
             package_path = parser.get('remote')
@@ -1471,6 +1482,7 @@ def default(package_path, use_gpg):
     configure_local('Calamari', package_path, use_gpg=use_gpg)
     configure_local('Installer', package_path, use_gpg=use_gpg)
     configure_local('Tools', package_path, use_gpg=use_gpg)
+    pin_local_repos()
 
     # step two, there's so much we can do
     # install calamari


### PR DESCRIPTION
Using `origin ""` in the apt pinning config will apply to all
local repos - e.g. anything starting with file:///

Put the config in a new rhcs.pref file so that if someone used
ceph-deploy repo command to add other repos, those will get pinned
in the ceph.pref file separately.

Here is output showing the pinning in action on  Trusty machine with RHCS 1.3.0 installed, but also with cloud-archive kilo installed (which has higher Ceph versions in it)

```
# apt-cache policy ceph
ceph:
  Installed: 0.94.1.4-1trusty
  Candidate: 0.94.1.4-1trusty
  Version table:
     0.94.2-0ubuntu0.15.04.1~cloud0 0
        500 http://ubuntu-cloud.archive.canonical.com/ubuntu/ trusty-updates/kilo/main amd64 Packages
 *** 0.94.1.4-1trusty 0
        999 file:/opt/ICE/Tools/ trusty/main amd64 Packages
        100 /var/lib/dpkg/status
     0.80.9-0ubuntu0.14.04.2 0
        500 http://archive.ubuntu.com/ubuntu/ trusty-updates/main amd64 Packages
     0.79-0ubuntu1 0
        500 http://archive.ubuntu.com/ubuntu/ trusty/main amd64 Packages
```

Note that 0.94.1.4 wins out (with prio 999) over the 0.94.2 version from ubuntu-cloud.archive.