### PR TITLE
use sudo instead of "as root"

### DIFF
--- a/ice_setup/ice.py
+++ b/ice_setup/ice.py
@@ -1561,9 +1561,9 @@ def default(package_path, use_gpg):
     logger.info('Setup has completed.')
     logger.info('If installing Calamari for the first time:')
     logger.info('')
-    logger.info('  Initialize Calamari (as root) by running:')
+    logger.info('  Initialize Calamari by running:')
     logger.info('')
-    logger.info('    calamari-ctl initialize')
+    logger.info('    sudo calamari-ctl initialize')
     logger.info('')
 
     logger.info('To install the ceph-osd repo files on remote nodes with ceph-deploy, run:')


### PR DESCRIPTION
Originally I thought that we should avoid sudo, but we decided to reverse that decision and now we're standardizing on sudo everywhere.

See https://bugzilla.redhat.com/1202734, "Initialize Calamari (as
root) by running: calamari-ctl initialize -- Inconsistent message
provided b/w Doc and the CLI"