### PR TITLE
fix pin_local_repos() on non-Apt systems

### DIFF
--- a/ice_setup/ice.py
+++ b/ice_setup/ice.py
@@ -785,11 +785,11 @@ class Debian(object):
     pkg_manager = Apt()
 
 
-def pin_local_repos(path='/etc/apt/preferences.d/rhcs.pref'):
+def pin_local_repos(path='/etc/apt/preferences.d/rhcs.pref', distro=None):
     """ Write apt preferences file """
 
     # Skip this on non-Apt-based systems.
-    distro = get_distro()
+    distro = distro or get_distro()
     if distro.pkg_manager.__class__.__name__ != 'Apt':
         return
 

--- a/ice_setup/ice.py
+++ b/ice_setup/ice.py
@@ -786,6 +786,13 @@ class Debian(object):
 
 
 def pin_local_repos(path='/etc/apt/preferences.d/rhcs.pref'):
+    """ Write apt preferences file """
+
+    # Skip this on non-Apt-based systems.
+    distro = get_distro()
+    if distro.pkg_manager.__class__.__name__ != 'Apt':
+        return
+
     template = ("Explanation: Prefer Red Hat packages\n"
                 "Package: *\n"
                 "Pin: release o=/Red Hat/\n"

--- a/ice_setup/tests/test_pin_local_repos.py
+++ b/ice_setup/tests/test_pin_local_repos.py
@@ -1,0 +1,15 @@
+import pytest
+from os.path import isfile
+from ice_setup.ice import pin_local_repos, CentOS, Debian
+
+class TestPinLocalRepos(object):
+
+    @pytest.mark.parametrize('distro,expected', [
+        (CentOS, False),
+        (Debian, True),
+    ])
+    def test_distro_writes_pref_file(self, distro, expected, tmpdir):
+        path = str(tmpdir.join('rhcs.pref'))
+        pin_local_repos(path=path, distro=distro)
+        # RPM distros should not write the apt prefs file
+        assert isfile(path) is expected


### PR DESCRIPTION
Commit 89b5d742a694c608485d2d6c7e2a9ce87e97a5bd added pin_local_repos(). This works great on Ubuntu, but breaks on CentOS, because it unconditionally writes an Apt prefs file there. This causes ice_setup to error with a stack trace because /etc/apt does not exist there.

If we're not on Debian or Ubuntu, skip writing the prefs file.