### PR TITLE
better errors when failing to write cephdeploy.conf

### DIFF
--- a/ice_setup/ice.py
+++ b/ice_setup/ice.py
@@ -32,6 +32,7 @@ import tempfile
 import urllib2
 import urlparse
 from ConfigParser import SafeConfigParser, NoSectionError, NoOptionError
+from errno import EROFS
 
 from functools import wraps
 from textwrap import dedent
@@ -1353,7 +1354,12 @@ def configure_remote(
 
     return destination_name
 
+def handle_ceph_deploy_ioerror(exc):
+    if exc.errno == EROFS:
+        print 'Error: Please ensure the current working directory is writable.'
+    raise SystemExit(exc)
 
+@catches(IOError, handler=handle_ceph_deploy_ioerror)
 def configure_ceph_deploy(master,
                           ceph_mon_url, ceph_mon_gpg_url,
                           ceph_osd_url, ceph_osd_gpg_url,

--- a/ice_setup/tests/test_configure_ceph_deploy.py
+++ b/ice_setup/tests/test_configure_ceph_deploy.py
@@ -1,0 +1,61 @@
+import __builtin__
+from errno import EROFS
+from os import mkdir
+from os.path import isfile
+
+import pytest
+
+from ice_setup.ice import configure_ceph_deploy
+
+class TestConfigureCephDeploy(object):
+
+    @pytest.fixture
+    def mock_ceph_deploy_dirs(self, tmpdir, monkeypatch):
+        """ configure_ceph_deploy() writes two files: one to the current
+            working directory, and one to $HOME. """
+
+        # monkeypatch cwd
+        monkeypatch.setattr('ice_setup.ice.CWD', str(tmpdir))
+
+        # monkeypatch HOME
+        monkeypatch.setenv('HOME', str(tmpdir.join('testuser')))
+        mkdir(str(tmpdir.join('testuser')))
+
+        return tmpdir
+
+
+    def test_write_files(self, mock_ceph_deploy_dirs):
+        """ Test the usual case of writing two cephdeploy.conf files. """
+        configure_ceph_deploy(
+            'master.example.com',
+            'http://master.example.com/ceph-mon/',
+            'http://master.example.com/release.asc',
+            'http://master.example.com/ceph-osd/',
+            'http://master.example.com/release.asc',
+            use_gpg=True,
+        )
+        cwd_file  = mock_ceph_deploy_dirs.join('cephdeploy.conf')
+        home_file = mock_ceph_deploy_dirs.join('testuser', '.cephdeploy.conf')
+        assert isfile(str(cwd_file)) is True
+        assert isfile(str(home_file)) is True
+
+
+    def mock_open_ioerror(self, *args, **kwargs):
+        """ Raises an EROFS IOError. Use this to mock the open() builtin. """
+        raise IOError(EROFS, 'Read-only file system: %s' % args[0])
+
+
+    def test_read_only_error(self, mock_ceph_deploy_dirs, monkeypatch):
+        """ Test when open() raises an EROFS IOError """
+        monkeypatch.setattr(__builtin__, 'open', self.mock_open_ioerror)
+
+        # We should see a regular SystemExit here, not IOError.
+        with pytest.raises(SystemExit):
+            configure_ceph_deploy(
+                'master.example.com',
+                'http://master.example.com/ceph-mon/',
+                'http://master.example.com/release.asc',
+                'http://master.example.com/ceph-osd/',
+                'http://master.example.com/release.asc',
+                use_gpg=True,
+            )


### PR DESCRIPTION
ice_setup doesn't check to see if CWD is writable before writing to `os.path.join(CWD, 'cephdeploy.conf')`. This can lead to a stack trace if CWD is not writable. Users commonly encounter this when running ice_setup while cd'd to the RHCS ISO mount path (/mnt), since that directory is read-only.

When we encounter a failure to write cephdeploy.conf, catch the IOError. If it's an EROFS error, print a friently message to the user. In any case, just print the error string itself, without printing a full stack trace.

(A longer-term fix in ice_setup itself would involve not writing so many cephdeploy.conf files.)