### PR TITLE
ice.py: show help message for `ice_setup update`

### DIFF
--- a/ice_setup/ice.py
+++ b/ice_setup/ice.py
@@ -1661,6 +1661,8 @@ class UpdateRepo(object):
                 else:
                     error_msg = "Unrecognized repo name(s) given: %s" % (", ".join(frozenset(parser.arguments).difference(self.optional_arguments)))
                     raise InvalidRepoName(error_msg)
+            else:
+                parser.print_help()
 
         return True
 


### PR DESCRIPTION
Prior to this change, if a user ran `sudo ice_setup update`, ice_setup with silently exit and it was not clear what happened.

Call Tambo's print_help() instead. This will instruct the user to run "update" with the third argument, such as `ice_setup update all` or `ice_setup update ceph-mon` or `ice_setup update ceph-osd`.
